### PR TITLE
Add --dev flag while install the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This package is a wrapper around [Carbon](https://carbon.nesbot.com/docs/)'s `se
 You can install the package via composer:
 
 ```bash
-composer require spatie/pest-plugin-test-time
+composer require spatie/pest-plugin-test-time --dev
 ```
 
 ## Usage


### PR DESCRIPTION
Hi Freek and Spatie teams,

I have a suggestion for the documentation of this package. I noticed that it could be useful to add the --dev flag when installing the package as a dev dependency.

Please feel free to disregard this suggestion if it is unnecessary. 
Thank you for your hard work and dedication. 😉 