### PR TITLE
laravel 11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2]
+        php: [8.1, 8.2, 8.3]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "nesbot/carbon": "^2.65",
+        "nesbot/carbon": "^2.65|^3",
         "pestphp/pest": "^2.0",
         "spatie/test-time": "^1.3.2"
     },

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -7,7 +7,7 @@ function testTime(): TestTime
     return new TestTime();
 }
 
-expect()->extend('toBeCarbon', function (string $expected, string $format = null) {
+expect()->extend('toBeCarbon', function (string $expected, ?string $format = null) {
     if ($format === null) {
         $format = str_contains($expected, ':')
             ? 'Y-m-d H:i:s'

--- a/src/TestTime.php
+++ b/src/TestTime.php
@@ -8,7 +8,7 @@ use Spatie\TestTime\TestTime as BaseTestTime;
 /** @mixin BaseTestTime|\Carbon\Carbon */
 class TestTime
 {
-    public function freeze(string $time = null, string $format = 'Y-m-d H:i:s'): Carbon
+    public function freeze(?string $time = null, string $format = 'Y-m-d H:i:s'): Carbon
     {
         if ($time === null) {
             $format = null;

--- a/tests/Functions.php
+++ b/tests/Functions.php
@@ -1,6 +1,7 @@
 <?php
 
 use Carbon\Carbon;
+
 use function Spatie\PestPluginTestTime\testTime;
 
 it('can freeze the time the current time', function () {


### PR DESCRIPTION
Laravel 11 is compatible "nesbot/carbon:^2.72.2|^3.0", if installed on a fresh installation, carbon v3 is fixed and when trying to install pest-plugin-test-time this fails. On the contrary, if we are in a Laravel 10 installation, some version ^2.X is fixed and when updating Laravel to v11 this works.