### PR TITLE
Add support for Pest 5

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,14 +9,14 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2, 8.3]
+        php: [8.4, 8.5]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,10 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "nesbot/carbon": "^2.65|^3",
-        "pestphp/pest": "^2.0|^3.0|^4.0",
+        "php": "^8.4",
+        "nesbot/carbon": "^3.0",
+        "pestphp/pest": "^4.0|^5.0",
         "spatie/test-time": "^1.3.2"
-    },
-    "require-dev": {
-        "spatie/ray": "^1.36"
     },
     "autoload": {
         "psr-4": {
@@ -43,7 +40,6 @@
             "pestphp/pest-plugin": true
         }
     },
-
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {

--- a/src/TestTime.php
+++ b/src/TestTime.php
@@ -5,7 +5,7 @@ namespace Spatie\PestPluginTestTime;
 use Carbon\Carbon;
 use Spatie\TestTime\TestTime as BaseTestTime;
 
-/** @mixin BaseTestTime|\Carbon\Carbon */
+/** @mixin BaseTestTime|Carbon */
 class TestTime
 {
     public function freeze(?string $time = null, string $format = 'Y-m-d H:i:s'): Carbon


### PR DESCRIPTION
Adds Pest 5 to the allowed versions. Pest 5 requires PHP 8.4, so the minimum PHP version moves to 8.4 and the CI matrix now runs 8.4 and 8.5.

Carbon 2 is dropped: it emits implicit-nullable deprecations on PHP 8.4+, and anything on PHP 8.4 is already on Carbon 3.

`spatie/ray` is removed from require-dev. It was not referenced anywhere in src or tests, and under prefer-lowest it pulled in a version that spammed deprecations.